### PR TITLE
Typo in except statement

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -1,0 +1,46 @@
+name: Python Syntax Check
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install ruff
+        run: uv tool install ruff
+
+      - name: Get changed Python files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            **/*.py
+
+      - name: Run ruff format check
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+          uv tool run ruff format --check ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Run ruff check
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          uv tool run ruff check ${{ steps.changed-files.outputs.all_changed_files }}

--- a/src/talk_python_cli/formatting.py
+++ b/src/talk_python_cli/formatting.py
@@ -68,7 +68,7 @@ def display_json(content: str) -> None:
     """Output JSON content — pretty-printed if on a TTY, raw otherwise."""
     try:
         data = json.loads(content)
-    except json.JSONDecodeError, TypeError:
+    except (json.JSONDecodeError, TypeError):
         # Server may have returned Markdown even though JSON was requested;
         # fall back to printing the raw text.
         console.print(content)


### PR DESCRIPTION
Script can't run with Exception syntax.

# Steps to replicate
1. Confirm that talk-python-cli is not installed
2. Install talk-python-cli using `uv run` (as seen in the README.md)
3. Run sample command from the README.md

# Error message
Fails with message that unparenthesized exceptions must be parenthesized:
```
packages/talk_python_cli/formatting.py", line 71
    except json.JSONDecodeError, TypeError:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

# The complete run
```
/tmp ❯ uv run -- talk-python-cli
error: Failed to spawn: `talk-python-cli`
  Caused by: No such file or directory (os error 2)

/tmp ❯ uv tool install talk-python-cli 
Resolved 17 packages in 124ms
Installed 17 packages in 15ms
 + anyio==4.12.1
 + attrs==25.4.0
 + certifi==2026.1.4
 + cyclopts==4.5.1
 + docstring-parser==0.17.0
 + docutils==0.22.4
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + idna==3.11
 + markdown-it-py==4.0.0
 + mdurl==0.1.2
 + pygments==2.19.2
 + rich==14.3.2
 + rich-rst==1.3.2
 + talk-python-cli==0.2.0
 + typing-extensions==4.15.0
Installed 1 executable: talkpython

/tmp ❯ talkpython episodes search "FastAPI"
Traceback (most recent call last):
  File "/Users/hughbrown/.local/bin/talkpython", line 4, in <module>
    from talk_python_cli.app import main
  File "/Users/hughbrown/.local/share/uv/tools/talk-python-cli/lib/python3.12/site-packages/talk_python_cli/app.py", line 15, in <module>
    from talk_python_cli.formatting import console, display_json, print_error
  File "/Users/hughbrown/.local/share/uv/tools/talk-python-cli/lib/python3.12/site-packages/talk_python_cli/formatting.py", line 71
    except json.JSONDecodeError, TypeError:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```